### PR TITLE
remove unnecessary crypto dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
   "author": "Per Guth <mail@perguth.de> (http://perguth.de/)",
   "license": "AGPLv3",
   "dependencies": {
-    "crypto": "0.0.3",
     "cuid": "^1.3.8",
     "events": "^1.1.0",
     "feature": "^1.0.0",


### PR DESCRIPTION
See https://medium.com/@rmehlinger/crypto-collision-f41c206de27b. This package has no license and no tests, and masks a built in NodeJS library. Thankfully, Node does not allow its crypto package to be overwritten by this thing, so requiring it doesn't actually do anything.